### PR TITLE
Add IP option to mesos-init-wrapper

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -110,6 +110,7 @@ function master {
   [[ ! -f /etc/default/mesos-master ]] || . /etc/default/mesos-master
   [[ ! ${ULIMIT:-} ]]  || ulimit $ULIMIT
   [[ ! ${ZK:-} ]]      || args+=( --zk="$ZK" )
+  [[ ! ${IP:-} ]]      || args+=( --ip="$IP" )
   [[ ! ${PORT:-} ]]    || args+=( --port="$PORT" )
   [[ ! ${CLUSTER:-} ]] || args+=( --cluster="$CLUSTER" )
   [[ ! ${LOGS:-} ]]    || args+=( --log_dir="$LOGS" )


### PR DESCRIPTION
For some stupid reasons my mesos masters were picking up 127.0.0.1 as their IP and using that when calling for an election. Then both of them ended up as the damned masters. I hacked my mesos-init-wrapper to take this option until I sort out my hosts file. :P
