### PR TITLE
There is no need to set recover=cleanup in general.

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -99,7 +99,6 @@ function slave {
     local formatted="$(printf ';%s' "${resources[@]}")"
     args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
   fi
-  ( logged /usr/local/sbin/mesos-slave --master="$MASTER" --recover=cleanup )
   logged /usr/local/sbin/mesos-slave "${args[@]}"
 }
 


### PR DESCRIPTION
We set it this way at one time to facilitate version upgrades, when slave
recovery was introduced. It probably should have been a post-upgrade action.
