### PR TITLE
Without cxx11

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -75,7 +75,7 @@ function build {(
   ./bootstrap
   mkdir -p build
   cd build
-  ../configure
+  ../configure $(configure_opts)
   # optimal number of build jobs is 2x num_cores
   make -j $(($(num_cores)*2))
 )}
@@ -286,6 +286,15 @@ function num_cores {
     fi
   fi
   out "$cores"
+}
+
+# Return Mesos configuration options
+function configure_opts {
+  local options=
+  if [[ "$version" == 0.18.0-rc4 ]] || [[ "$repo" =~ 0\.18\.0-rc4$ ]]
+  then options="--without-cxx11"                # See: MESOS-750 and MESOS-1095
+  fi
+  out "$options"
 }
 
 function msg { out "$*" >&2 ;}


### PR DESCRIPTION
Addresses the issue causing ubuntu/raring, ubuntu/quantal, and debian/wheezy builds to fail.
- Add a function for determining configure options.
- Configure --without-cxx11 for Mesos 0.18.0-rc4. See [MESOS-750](https://issues.apache.org/jira/browse/MESOS-750) and [MESOS-1095](https://issues.apache.org/jira/browse/MESOS-1095) (should be resolved in Mesos core 0.18.0-rc5.)
