### PR TITLE
Add --config-files so etc files don't get overwritten

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -231,6 +231,7 @@ and iterative jobs), and other applications."
                --category misc
                --vendor ""
                -m mesos-dev@incubator.apache.org
+               --config-files etc/
                --prefix=/ )
   ( cd toor && "$gem_bin"/fpm "${opts[@]}" "$@" -- . )
 }


### PR DESCRIPTION
Fixes mesosphere/mesos-deb-packaging#3

NOTE: The packaged conffiles doesn't use absolute paths and will fail lintian tests. jordansissel/fpm@1dfbdfdd8d75164286a50a2caacc42e9c2e140a0 of fpm fixes this, but it is not available on RubyGems yet.
