### PR TITLE
Default to registry=in_memory for 0.19.0-rc1

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -138,7 +138,7 @@ function create_installation {(
   cp "$this"/default/mesos*     etc/default/
   echo zk://localhost:2181/mesos > etc/mesos/zk
   # Disable registry replicated log since it requires manual configuration
-  if [[ "$version" == 0.19.0-rc1 ]] || [[ "$repo" =~ 0\.19\.0-rc1$ ]]
+  if [[ "$version" =~ 0.19.0-rc[12] ]] || [[ "$repo" =~ 0\.19\.0-rc[12]$ ]]
   then echo in_memory > etc/mesos-master/registry
   fi
   init_scripts "$linux"


### PR DESCRIPTION
The default in 0.19.0-rc1 is to enable the registry and use a replicated log. Unfortunately, this requires manual configuration of the new options: --work_dir and --quorum. For now, we will build the 0.19.0-rc1 package with the registry set to in_memory by default, to ensure mesos can still start without manual configuration. The mesos-master registry default setting may change during the 0.19.0-rcX release process.
