### PR TITLE
Support release versioning and snap builds

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -3,7 +3,9 @@ set -o errexit -o nounset -o pipefail
 export LC_ALL=C
 function -h {
 cat <<USAGE
- USAGE: build_mesos (--repo <git URL>)? (--nominal-version <version>)?
+ USAGE: build_mesos (--repo <git URL>)? \
+                    (--nominal-version <version>)? \
+                    (--build-version <debian_revision or rpm release>)?
 
   Performs a build in ./mesos-repo after checking out a recent copy of Mesos.
   The default is to checkout:
@@ -23,13 +25,15 @@ USAGE
 this="$(cd "$(dirname "$0")" && pwd -P)"
 name=mesos
 version="${version:-9999}"
+build_version="0.1.$(date -u +'%Y%m%d%H%M%S')"
 
 function main {
   while [[ $# -gt 0 ]]
   do
     case "$1" in                                      # Munging globals, beware
-      --repo)                   repo="$2"    ; shift 2 ;;
-      --nominal-version)        version="$2" ; shift 2 ;;
+      --repo)                   repo="$2"          ; shift 2 ;;
+      --nominal-version)        version="$2"       ; shift 2 ;;
+      --build-version)          build_version="$2" ; shift 2 ;;
       *)                        err 'Argument error. Please see help.' ;;
     esac
   done
@@ -235,6 +239,7 @@ function fpm_ {
   local opts=( -s dir
                -n "$name"
                -v "$version"
+               --iteration "$build_version"
                --description
 "Cluster resouce manager with efficient resource isolation
 Apache Mesos is a cluster manager that offers efficient resource isolation


### PR DESCRIPTION
If the version consists of two components (package version and
release/build version), it is necessary to explicitly specify each when
building with fpm. This is particularly important for rpm packages...
otherwise a version string of "0.19.0-1.0.centos64" will end up as:

```
Version     : 0.19.0_1.0.centos64
Release     : 1
```

Instead of:

```
Version     : 0.19.0
Release     : 1.0.centos64
```

This patch also supports "snapshot" builds by default, which is just a
release version set to 0.1.$UTC_TIMESTAMP
