### PR TITLE
Fix as_absolute to work correctly

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -55,7 +55,7 @@ function globals {
 }; globals
 
 function as_absolute {
-  if [[ "$1" == "/*" ]]; then
+  if [[ "$1" == /* ]]; then
     echo "$1"
   else
     echo "$start_dir/$1"


### PR DESCRIPTION
Putting it in quotes caused it to be a literal string comparison rather than a glob expansion comparison.
