### PR TITLE
Change configure prefix to install packages to /usr

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -381,13 +381,13 @@ function url_split {
 
 # Return Mesos configuration options
 function configure_opts {
-  local options=
+  local options="--prefix=/usr"
   if [[ "$version" == 0.18.0-rc4 ]] || [[ "$repo" =~ 0\.18\.0-rc4$ ]]
-  then options="--without-cxx11"                # See: MESOS-750 and MESOS-1095
+  then options+=" --without-cxx11"                # See: MESOS-750 and MESOS-1095
   fi
   if [[ $(vercomp "$version" 0.21.0) == '>' ]] ||
      [[ $(vercomp "$version" 0.21.0) == '=' ]]
-  then options="--enable-optimize"
+  then options+=" --enable-optimize"
   fi
 
   out "$options"


### PR DESCRIPTION
Switch options to be built by string appending on a base case.

Spaces before each of the existing options so they'll work being appended / not run together.