### PR TITLE
enable cpu and memory accounting for mesos-slave

### DIFF
--- a/systemd/slave.systemd
+++ b/systemd/slave.systemd
@@ -9,6 +9,8 @@ Restart=on-abort
 Restart=always
 RestartSec=20
 LimitNOFILE=16384
+CPUAccounting=true
+MemoryAccounting=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This enables CPU and Memory accounting.
Ran into this when trying to use cgroups/cpu,cgroups/mem isolator on CentOS 7. Without it mesos-slave will start but is unable to run tasks.
