### PR TITLE
add call to mesosphere-dnsconfig if tool is installed

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -63,6 +63,7 @@ function slave {
   local args=()
   local attributes=()
   local resources=()
+  [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig -write -service=mesos-slave
   [[ ! -f /etc/default/mesos ]]       || . /etc/default/mesos
   [[ ! -f /etc/default/mesos-slave ]] || . /etc/default/mesos-slave
   [[ ! ${ULIMIT:-} ]]    || ulimit $ULIMIT
@@ -105,6 +106,7 @@ function slave {
 function master {
   local etc_master=/etc/mesos-master
   local args=()
+  [ -x /usr/bin/mesosphere-dnsconfig ] && mesosphere-dnsconfig -write -service=mesos-master
   [[ ! -f /etc/default/mesos ]]        || . /etc/default/mesos
   [[ ! -f /etc/default/mesos-master ]] || . /etc/default/mesos-master
   [[ ! ${ULIMIT:-} ]]  || ulimit $ULIMIT


### PR DESCRIPTION
Calls mesosphere-dnsconfig on master/slave start, if tool is installed on the system.