### PR TITLE
allow for disabling output to syslog with USE_SYSLOG=0

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -101,7 +101,12 @@ function slave {
     local formatted="$(printf ';%s' "${resources[@]}")"
     args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
   fi
-  logged /usr/sbin/mesos-slave "${args[@]}"
+
+  if [[ "${args[@]:-}" == *'--no-logger'* ]]; then
+    /usr/sbin/mesos-slave "${args[@]//--no-logger/}"
+  else
+    logged /usr/sbin/mesos-slave "${args[@]:-}"
+  fi
 }
 
 function master {
@@ -128,7 +133,12 @@ function master {
       fi
     fi
   done
-  logged /usr/sbin/mesos-master "${args[@]}"
+
+  if [[ "${args[@]:-}" == *'--no-logger'* ]]; then
+    /usr/sbin/mesos-master "${args[@]//--no-logger/}"
+  else
+    logged /usr/sbin/mesos-master "${args[@]:-}"
+  fi
 }
 
 # Send all output to syslog and tag with PID and executable basename.

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -102,8 +102,15 @@ function slave {
     args+=( --resources="${formatted:1}" )         # NB: Leading ';' is clipped
   fi
 
-  if [[ "${args[@]:-}" == *'--no-logger'* ]]; then
-    /usr/sbin/mesos-slave "${args[@]//--no-logger/}"
+  if [[ "${args[@]:-}" == *'--no-logger'* ]]
+  then
+    local clean_args=()
+    for i in "${args[@]}"; do
+      if [[ "${i}" != "--no-logger" ]]; then
+        clean_args+=( "${i}" )
+      fi
+    done
+    /usr/sbin/mesos-slave "${clean_args[@]}"
   else
     logged /usr/sbin/mesos-slave "${args[@]:-}"
   fi
@@ -134,8 +141,15 @@ function master {
     fi
   done
 
-  if [[ "${args[@]:-}" == *'--no-logger'* ]]; then
-    /usr/sbin/mesos-master "${args[@]//--no-logger/}"
+  if [[ "${args[@]:-}" == *'--no-logger'* ]]
+  then
+    local clean_args=()
+    for i in "${args[@]}"; do
+      if [[ "${i}" != "--no-logger" ]]; then
+        clean_args+=( "${i}" )
+      fi
+    done
+    /usr/sbin/mesos-master "${clean_args[@]}"
   else
     logged /usr/sbin/mesos-master "${args[@]:-}"
   fi


### PR DESCRIPTION
This makes mesos-init-wrapper more compatible with supervisor and systemd, or anyone else who doesn't want all of their application logs sent to syslog.