### PR TITLE
add dependency to cyrus-sasl-md5 modules

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -295,6 +295,7 @@ function deb_ {
                -d 'java-runtime-headless'
                -d libcurl3
                -d libsvn1
+               -d libsasl2-modules
                --after-install "$this/$asset_dir/mesos.postinst"
                --after-remove "$this/$asset_dir/mesos.postrm" )
   rm -f "$this"/pkg.deb
@@ -305,6 +306,7 @@ function rpm_ {
   local opts=( -t rpm
                -d libcurl
                -d subversion
+               -d cyrus-sasl-md5
                --after-install "$this/$asset_dir/mesos.postinst"
                --after-remove "$this/$asset_dir/mesos.postrm" )
   rm -f "$this"/pkg.rpm


### PR DESCRIPTION
Cyrus SASL MD5 is a runtime dependency. According to @tillt it has been for a while but because it's only loaded when used nobody seems to have noticed. On Debian/Ubuntu systems it's part of the sasl modules package which is usually installed. On Fedora derived systems it's packaged as a standalone and usually missing. I added a dependency for both, the deb and the rpm to pull in this module.