### PR TITLE
Fix multiplexing daemon output into syslog

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -133,9 +133,17 @@ function master {
 
 # Send all output to syslog and tag with PID and executable basename.
 function logged {
+  local pattern="[0-9]\{4\} [0-9]\{2\}:[0-9]\{2\}:[0-9]\{2\}.[0-9]* "
   local tag="${1##*/}[$$]"
-  exec 1> >(exec logger -p user.info -t "$tag")
-  exec 2> >(exec logger -p user.err  -t "$tag")
+  exec 1> >(
+    tee \
+      >(sed -n "/^I$pattern/ s/// p" | logger -p user.info -t "$tag" ) \
+      >(sed -n "/^W$pattern/ s/// p" | logger -p user.warn -t "$tag" ) \
+      >(sed -n "/^E$pattern/ s/// p" | logger -p user.err  -t "$tag" ) \
+      >(sed -n "/^F$pattern/ s/// p" | logger -p user.crit -t "$tag" ) \
+      > /dev/null
+  )
+  exec 2>&1
   exec "$@"
 }
 

--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -141,6 +141,7 @@ function logged {
       >(sed -n "/^W$pattern/ s/// p" | logger -p user.warn -t "$tag" ) \
       >(sed -n "/^E$pattern/ s/// p" | logger -p user.err  -t "$tag" ) \
       >(sed -n "/^F$pattern/ s/// p" | logger -p user.crit -t "$tag" ) \
+      >(grep -v "^[IWEF]$pattern"    | logger -p user.crit -t "$tag" ) \
       > /dev/null
   )
   exec 2>&1


### PR DESCRIPTION
Mesos master and slave daemon attempt to multiplex stdout and stderr into info
and crit syslog severities, but it does not work properly and forwards all log
output into err severity only.

Use first character of each log message to distinguish its severity and multiplex
them into appropriate syslog severities. This fixes #15.

The multiplexing also removes timestamp from log message as syslog would add its
own and having two timestamps would make logs unreadable.