### PR TITLE
allow extra runtime libraries to be added to the distribution

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -52,6 +52,7 @@ function globals {
   repo=https://git-wip-us.apache.org/repos/asf/mesos.git
   use_git_version=false
   prebuilt=false
+  extra_libs=''
 }; globals
 
 function as_absolute {
@@ -73,6 +74,7 @@ function main {
       --branch)                 branch="$2"        ; shift 2 ;;
       --nominal-version)        version="$2"       ; shift 2 ;;
       --build-version)          build_version="$2" ; shift 2 ;;
+      --extra-libs)             extra_libs="$2"    ; shift 2 ;;
       *)                        err 'Argument error. Please see help.' ;;
     esac
   done
@@ -152,6 +154,7 @@ function checkout {
 }
 
 function build {(
+  export LD_RUN_PATH=/usr/lib/mesos
   autoreconf -f -i -Wall,no-obsolete
   ./bootstrap
   mkdir -p "$build_dir"
@@ -223,6 +226,7 @@ function create_installation {(
     echo /var/lib/mesos          > etc/mesos-master/work_dir
     echo 1                       > etc/mesos-master/quorum
   fi
+  extra_libs
   init_scripts "$linux"
   jars
 )}
@@ -257,6 +261,18 @@ function init_scripts {
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
     *) err "Not sure how to make init scripts for: $1" ;;
   esac
+}
+
+function extra_libs {
+  if [ -n "$extra_libs" ]
+  then
+    mkdir -p usr/lib/mesos
+    IFS=";"
+    for lib in $extra_libs
+    do
+      cp -f $lib usr/lib/mesos/
+    done
+  fi
 }
 
 function jars {


### PR DESCRIPTION
This function allows to define a list of additional libraries which will be copied to /usr/lib/mesos. This path is set as LD_RUN_PATH during linking. I am using this to add a recent libstdc++ compiler runtime on older distributions like Ubuntu 12.04 but it could be used for any runtime libraries.