### PR TITLE
add Support for Debian 8 and Ubuntu 15.04

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -247,6 +247,10 @@ function init_scripts {
   mkdir -p usr/bin
   cp -p "$this"/mesos-init-wrapper usr/bin
   case "$1" in
+    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*|debian/8*|ubuntu/15*)
+      mkdir -p usr/lib/systemd/system
+      cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
+      cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
     debian/*)
       mkdir -p etc/init.d
       cp -p "$this"/init/master.init etc/init.d/mesos-master
@@ -255,10 +259,6 @@ function init_scripts {
       mkdir -p etc/init
       cp "$this"/upstart/master.upstart etc/init/mesos-master.conf
       cp "$this"/upstart/slave.upstart etc/init/mesos-slave.conf ;;
-    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*)
-      mkdir -p usr/lib/systemd/system
-      cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
-      cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
     *) err "Not sure how to make init scripts for: $1" ;;
   esac
 }

--- a/build_mesos
+++ b/build_mesos
@@ -247,10 +247,14 @@ function init_scripts {
   mkdir -p usr/bin
   cp -p "$this"/mesos-init-wrapper usr/bin
   case "$1" in
-    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*|debian/8*|ubuntu/15*)
+    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*)
       mkdir -p usr/lib/systemd/system
       cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
+    debian/8*|ubuntu/15*)
+      mkdir -p lib/systemd/system
+      cp "$this"/systemd/master.systemd lib/systemd/system/mesos-master.service
+      cp "$this"/systemd/slave.systemd lib/systemd/system/mesos-slave.service ;;
     debian/*)
       mkdir -p etc/init.d
       cp -p "$this"/init/master.init etc/init.d/mesos-master

--- a/debian/8/mesos.postinst
+++ b/debian/8/mesos.postinst
@@ -1,0 +1,3 @@
+ldconfig
+systemctl enable mesos-master
+systemctl enable mesos-slave

--- a/debian/8/mesos.postrm
+++ b/debian/8/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+

--- a/ubuntu/15.04/mesos.postinst
+++ b/ubuntu/15.04/mesos.postinst
@@ -1,0 +1,3 @@
+ldconfig
+systemctl enable mesos-master
+systemctl enable mesos-slave

--- a/ubuntu/15.04/mesos.postrm
+++ b/ubuntu/15.04/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+


### PR DESCRIPTION
This adds Support for Debian 8 and Ubuntu 15.04 which are both systemd based.
The postinst Scripts and Unit files are a copy of what we're using for EL7.
Only difference is that EL has it's unit files in /usr/lib/systemd/system whereas Debian/Ubuntu has them in /lib/systemd/system