### PR TITLE
Using posix launcher on CentOS 6 and Ubuntu 12.04

### DIFF
--- a/centos/mesos.postinst
+++ b/centos/mesos.postinst
@@ -1,2 +1,3 @@
 ldconfig
+echo posix > /etc/mesos-slave/launcher
 

--- a/ubuntu/12.04/mesos.postinst
+++ b/ubuntu/12.04/mesos.postinst
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+
+  configure|abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+# TODO we should restart mesos-slave or master
+
+#run ldconfig in order to have available libmesos.so
+
+ldconfig
+echo posix > /etc/mesos-slave/launcher
+
+#DEBHELPER#
+
+exit 0
+

--- a/ubuntu/12.04/mesos.postrm
+++ b/ubuntu/12.04/mesos.postrm
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+  purge)
+    rm -rf /var/log/mesos /etc/mesos
+    ;;
+
+  remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+
+  *)
+    echo "postrm called with unknown argument \`$1'" >&2
+    exit 1
+esac
+
+#DEBHELPER#
+
+exit 0
+


### PR DESCRIPTION
Enabling posix launcher for Mesos slave, because it seems like cgroups are not always available by default on CentOS 6 and Ubuntu 12.04.