### PR TITLE
Add build-essential to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Mesos is a cluster manager that provides efficient resource isolation and sharin
   * prerequisites:
 
 ```
-    sudo apt-get install ruby ruby-dev python-dev autoconf automake git make libssl-dev libcurl3 libtool
+    sudo apt-get install ruby ruby-dev python-dev autoconf automake git make libssl-dev libcurl3 \ 
+    	libtool build-essential
     sudo gem install fpm
 ```
 


### PR DESCRIPTION
On an Ubuntu 14.04 machine I received the following error when installing fpm without build-essential installed 

```
root@vagrant:/vagrant#  sudo gem install fpm
Fetching: json-1.8.3.gem (100%)
Building native extensions.  This could take a while...
ERROR:  Error installing fpm:
        ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.9.1 extconf.rb
creating Makefile

make
compiling generator.c
make: gcc: Command not found
make: *** [generator.o] Error 127


Gem files will remain installed in /var/lib/gems/1.9.1/gems/json-1.8.3 for inspection.
Results logged to /var/lib/gems/1.9.1/gems/json-1.8.3/ext/json/ext/generator/gem_make.out
```
