### PR TITLE
Disable services by default

### DIFF
--- a/centos/7/mesos.postinst
+++ b/centos/7/mesos.postinst
@@ -1,3 +1,1 @@
 ldconfig
-systemctl enable mesos-master
-systemctl enable mesos-slave

--- a/debian/8/mesos.postinst
+++ b/debian/8/mesos.postinst
@@ -1,3 +1,1 @@
 ldconfig
-systemctl enable mesos-master
-systemctl enable mesos-slave

--- a/debian/mesos.postinst
+++ b/debian/mesos.postinst
@@ -1,24 +1,6 @@
 #!/bin/sh
 set -e
 
-case "$1" in
-
-  configure)
-    update-rc.d mesos-master defaults
-    update-rc.d mesos-slave defaults
-    ;;
-
-  configure|abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-  *)
-    echo "postinst called with unknown argument \`$1'" >&2
-    exit 1
-    ;;
-esac
-
-# TODO we should restart mesos-slave or master
-
 #run ldconfig in order to have available libmesos.so
 
 ldconfig

--- a/fedora/mesos.postinst
+++ b/fedora/mesos.postinst
@@ -1,3 +1,1 @@
 ldconfig
-systemctl enable mesos-master
-systemctl enable mesos-slave

--- a/redhat/7/mesos.postinst
+++ b/redhat/7/mesos.postinst
@@ -1,3 +1,1 @@
 ldconfig
-systemctl enable mesos-master
-systemctl enable mesos-slave

--- a/ubuntu/15.04/mesos.postinst
+++ b/ubuntu/15.04/mesos.postinst
@@ -1,3 +1,1 @@
 ldconfig
-systemctl enable mesos-master
-systemctl enable mesos-slave


### PR DESCRIPTION
This changes removes code enabling services by installing the package.
The reasons you don't want enabled services by default is:

 * provisioning tools like puppet/chef/ansible should handle states of services
 * installing just a mesos-master should not spawn a mesos-slave silently (after reboot)
 * installing just a mesos-slave should not spawn a mesos-master silently (after reboot)
 * installing the package just to get the libmesos.so (e.g. on a jenkins) for running a framework should not spawn mesos-master and mesos-slave (after reboot)