### PR TITLE
Added dependency on libcurl4-nss-dev to Debian packaging

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -314,6 +314,7 @@ function deb_ {
                --deb-recommends zookeeper-bin
                -d 'java-runtime-headless'
                -d libcurl3
+               -d libcurl4-nss-dev
                -d libsvn1
                -d libsasl2-modules
                --after-install "$this/$asset_dir/mesos.postinst"


### PR DESCRIPTION
When building on Ubuntu 15.10, the resulting package has a hard
dependency on this lib but it's not listed in the fpm so it has to be
manually installed after mesos. Not sure how this affects other debian-based
distributions but as-is, the package doesn't work when built for the 
15.10 platform
