### PR TITLE
Fix OpenJDK dependency (again!!!)

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -328,7 +328,7 @@ function deb_ {
                --deb-recommends zookeeper
                --deb-recommends zookeeperd
                --deb-recommends zookeeper-bin
-               -d 'java-runtime-headless'
+               -d 'java-runtime-headless | java2-runtime-headless | default-jre'
                -d libcurl3
                -d libsvn1
                -d libsasl2-modules


### PR DESCRIPTION
Long story short, if you have the misfortune of upgrading your
openjdk-8-jre to >= 8u77, your Mesos cluster will self destruct.

Upstream Debian bug #815475:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=815475

> openjdk-8-jre should no longer provide java-runtime (default-jre should be used)

So in true OSS style, they "fix" it by removing the old virtual package, but apparently
did not take the second statement to heart -- never added the new virtual package!

http://bazaar.launchpad.net/~openjdk/openjdk/openjdk8/revision/672/debian/control

So let's just add all three -- the "old one that worked", the "new one that still
works", and the "one the docs say that doesn't work" as possibilities.

Someday we will have packaging that solves more problems than it causes...
Ha, who am I kidding...

(tag @SegFaultAX @carlf @pennello @strykerd)