### PR TITLE
exec the mesos daemons when not configured to use syslog

### DIFF
--- a/mesos-init-wrapper
+++ b/mesos-init-wrapper
@@ -112,7 +112,7 @@ function slave {
         clean_args+=( "${i}" )
       fi
     done
-    /usr/sbin/mesos-slave "${clean_args[@]}"
+    exec /usr/sbin/mesos-slave "${clean_args[@]}"
   else
     logged /usr/sbin/mesos-slave "${args[@]:-}"
   fi
@@ -153,7 +153,7 @@ function master {
         clean_args+=( "${i}" )
       fi
     done
-    /usr/sbin/mesos-master "${clean_args[@]}"
+    exec /usr/sbin/mesos-master "${clean_args[@]}"
   else
     logged /usr/sbin/mesos-master "${args[@]:-}"
   fi


### PR DESCRIPTION
There's a small feature discrepancy between the branch of code that does the typical log-to-syslog daemon launch, and the alternate path that does not log to syslog.  The logging path exec's the mesos binaries and the other does not.

When wrapped by another daemon framework (other than systemd which technically handles the process ownership with cgroups) this can lead to processes escaping during restart.