### PR TITLE
Do not auto-install python deps.

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -449,6 +449,12 @@ function configure_opts {
     options+=" --enable-libevent --enable-ssl"
   fi
 
+  # Do not auto-install python dependencies. This can cause the
+  # package to overwrite system installed packages such as setuptools
+  # and python-protobuf. Instead, we should explicitly list specific
+  # python dependencies.
+  options += " --disable-python-dependency-install"
+
   out "$options"
 }
 


### PR DESCRIPTION
Previously, the mesos deb/rpm package tried to automatically
install/overwrite some python packages such as setuptools and python
protobuf. This can lead to installation failure if the said python
packages are already installed on the system.