### PR TITLE
Add support for "rhel" os-release

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -224,7 +224,7 @@ function os_release {
 function display_version {
   local os="$( tr A-Z a-z <<<"$1" )" version="$( tr A-Z a-z <<<"$2" )"
   case "$os" in
-    redhat|centos|debian|fedora) out "$os/${version%%.*}" ;;   # Ignore minor versions
+    redhat|rhel|centos|debian|fedora) out "$os/${version%%.*}" ;;   # Ignore minor versions
     macosx)               out "$os/${version%.*}" ;;  # Ignore bug fix releases
     *)                    out "$os/$version" ;;
   esac
@@ -268,7 +268,7 @@ function init_scripts {
   mkdir -p usr/bin
   cp -p "$this"/mesos-init-wrapper usr/bin
   case "$1" in
-    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*)
+    fedora/*|redhat/7|redhat/7.*|centos/7|centos/7.*|rhel/7|rhel/7.*)
       mkdir -p usr/lib/systemd/system
       cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
@@ -311,7 +311,7 @@ function jars {
 function pkg {
   case "$linux" in
     ubuntu/*|debian/*) deb_ ;;
-    centos/*|redhat/*|fedora/*) rpm_ ;;
+    centos/*|redhat/*|rhel/*|fedora/*) rpm_ ;;
     *)                 err "Not sure how to package for: $linux" ;;
   esac
 }
@@ -319,7 +319,7 @@ function pkg {
 function architecture {
   case "$linux" in
     ubuntu/*|debian/*) dpkg-architecture -qDEB_BUILD_ARCH ;;
-    centos/*|redhat/*|fedora/*) arch ;;
+    centos/*|redhat/*|rhel/*|fedora/*) arch ;;
     *)                 err "Not sure how to determine arch for: $linux" ;;
   esac
 }
@@ -348,7 +348,9 @@ function rpm_ {
 
   case "$linux" in
     centos/6) libevent_devel_pkg=libevent2-devel ;;
+    rhel/6) libevent_devel_pkg=libevent2-devel ;;
     centos/7) libevent_devel_pkg=libevent-devel ;;
+    rhel/7) libevent_devel_pkg=libevent-devel ;;
     *)        err "Unknown CentOS distribution: $linux" ;;
   esac
 

--- a/rhel/7/mesos.postinst
+++ b/rhel/7/mesos.postinst
@@ -1,0 +1,3 @@
+ldconfig
+systemctl enable mesos-master
+systemctl enable mesos-slave

--- a/rhel/7/mesos.postrm
+++ b/rhel/7/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+

--- a/rhel/mesos.postinst
+++ b/rhel/mesos.postinst
@@ -1,0 +1,2 @@
+ldconfig
+

--- a/rhel/mesos.postrm
+++ b/rhel/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+


### PR DESCRIPTION
When trying to package on default AWS RHEL 7.1 or 7.2 image, build_mesos required case statements for type "rhel":

```
cat /etc/os-release 
NAME="Red Hat Enterprise Linux Server"
VERSION="7.1 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="7.1"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.1 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.1:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.1
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.1"
```

Update also provides os-release directory structure. 