### PR TITLE
Added libcurl4-nss-dev as deb dependency

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -348,6 +348,7 @@ function deb_ {
                --deb-recommends zookeeper-bin
                -d 'java-runtime-headless | java2-runtime-headless | default-jre'
                -d libcurl3
+               -d libcurl4-nss-dev
                -d libevent-dev
                -d libsvn1
                -d libsasl2-modules


### PR DESCRIPTION
Mandatory for debian based OS after mesos 1.2 upgrade (see https://github.com/mesosphere/mesos-deb-packaging/issues/102)
Package libcurl4-nss-dev exists on all supported versions (debian 7, 8 and Ubuntu XX)