### PR TITLE
Add libcurl3-nss as deb dependency

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -348,6 +348,7 @@ function deb_ {
                --deb-recommends zookeeper-bin
                -d 'java-runtime-headless | java2-runtime-headless | default-jre'
                -d libcurl3
+               -d libcurl3-nss
                -d libevent-dev
                -d libsvn1
                -d libsasl2-modules


### PR DESCRIPTION
Mandatory since mesos 1.2