### PR TITLE
Add missing libcurl3-nss dep for Deb package

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -351,6 +351,7 @@ function deb_ {
                -d libevent-dev
                -d libsvn1
                -d libsasl2-modules
+               -d libcurl3-nss
                --after-install "$this/$asset_dir/mesos.postinst"
                --after-remove "$this/$asset_dir/mesos.postrm" )
   pkgname="pkg"


### PR DESCRIPTION
Hello,

After upgrading to newer Mesosphere Debian package, everything stopped working.
The reason is that binaries are now linked to libcurl but there was no dependency added to the packaging:

```
root@toad.service.domain.com:~# ldd /usr/libexec/mesos/mesos-fetcher | grep libcurl
	libcurl-nss.so.4 => /usr/lib/x86_64-linux-gnu/libcurl-nss.so.4 (0x00007f3adde5d000)

root@toad.service.domain.com:~# dpkg -S libcurl-nss.so.4
libcurl3-nss:amd64: /usr/lib/x86_64-linux-gnu/libcurl-nss.so.4.3.0
libcurl3-nss:amd64: /usr/lib/x86_64-linux-gnu/libcurl-nss.so.4
```

Installing this package fixed the issue.

Btw, are you building packages on a Debian box (according to the apt-get install statement in the build documentation, I guess you do ;-)) ?
It would be quite easier and waaay better to generate a real Debian package, with debhelper. It'll take care of binaries dependencies, ldconfig, systemd stuff etc...

I can work on that if you're interested.

Regards, Adam.