### PR TITLE
Revert "Fixed regex for disable-python."

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -113,7 +113,7 @@ function go {
   create_installation
   create_lib_symlinks
   pkg
-  if [[ ! $(configure_opts) =~ "--disable-python\>" ]]
+  if [[ ! $(configure_opts) =~ "--disable-python" ]]
   then
     save_python_egg
   fi	  
@@ -254,7 +254,7 @@ function create_installation {(
   fi
   extra_libs
   init_scripts "$linux"
-  if [[ ! $(configure_opts) =~ "--disable-java\>" ]]
+  if [[ ! $(configure_opts) =~ "--disable-java" ]]
   then
     jars
   fi


### PR DESCRIPTION
@karya0 I am reverting  commit 41157b81ac6c523987695ac58416bc2b975552f2 as it seems it is wrong, proof:

```
$ ac='--prefix=/usr --enable-optimize --disable-python --enable-libevent --enable-ssl --disable-python-dependency-install'
$ [[ $ac =~ "--disable-python\>" ]] && echo match || echo no
no
$ [[ $ac =~ "--disable-python" ]] && echo match || echo no
match
```

As you can see, the match doesn't work when ``\>`` is appended, and sure enough if you run with e.g. ``./build_mesos --configure-flags "--disable-python"`` the build will fail because it still tries to run ``save_python_egg``
Is there any particular reason you changed this from (what seems to me) a working version?