### PR TITLE
Fix the .deb build to use libcurl4-openssl-dev instead of libcurl4-nss-dev

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -116,7 +116,7 @@ function go {
   if [[ ! $(configure_opts) =~ "--disable-python\>" ]]
   then
     save_python_egg
-  fi	  
+  fi
 }
 
 function mesos_version {
@@ -351,7 +351,7 @@ function deb_ {
                -d libevent-dev
                -d libsvn1
                -d libsasl2-modules
-               -d libcurl4-nss-dev
+               -d libcurl4-openssl-dev
                --after-install "$this/$asset_dir/mesos.postinst"
                --after-remove "$this/$asset_dir/mesos.postrm" )
   pkgname="pkg"


### PR DESCRIPTION
Purpose
--
This PR is a fix to avoid fetcher errors when "curling" for `HTTPS` scheme `URIs` on Debian distros.
An original Jira ticket was `accepted`: https://issues.apache.org/jira/browse/MESOS-2923

Trace
--
Error example:
```
I1005 08:44:46.258061  8717 fetcher.cpp:444] Fetching URI 'https://gist.githubusercontent.com/foobar/ID/raw/ID/my_file'
I1005 08:44:46.258075  8717 fetcher.cpp:285] Fetching directly into the sandbox directory
I1005 08:44:46.258088  8717 fetcher.cpp:222] Fetching URI 'https://gist.githubusercontent.com/foobar/ID/raw/ID/my_file'
I1005 08:44:46.258096  8717 fetcher.cpp:165] Downloading resource from 'https://gist.githubusercontent.com/foobar/ID/raw/ID/my_file' to '/data/mesos-slave/slaves/ID/frameworks/ID/runs/ID/my_file'
Failed to fetch 'https://gist.githubusercontent.com/foobar/ID/raw/ID/my_file': Error downloading resource: Problem with the SSL CA cert (path? access rights?)
```

Misc
--
This was mentioned in the past for Docker containers: https://github.com/apache/mesos/pull/48

