### PR TITLE
Added support for building for Ubuntu 18.04 targets

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -285,7 +285,7 @@ function init_scripts {
       mkdir -p usr/lib/systemd/system
       cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
-    debian/8*|debian/9*|ubuntu/15*|ubuntu/16*|ubuntu/17*)
+    debian/8*|debian/9*|ubuntu/15*|ubuntu/16*|ubuntu/17*|ubuntu/18*)
       mkdir -p lib/systemd/system
       cp "$this"/systemd/master.systemd lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd lib/systemd/system/mesos-slave.service ;;
@@ -342,12 +342,18 @@ function find_gem_bin {
 }
 
 function deb_ {
+  local libcurl_package
+  case "$linux" in
+    ubuntu/18*) libcurl_package="libcurl4" ;;
+    *)          libcurl_package="libcurl3" ;;
+  esac
+
   local opts=( -t deb
                --deb-recommends zookeeper
                --deb-recommends zookeeperd
                --deb-recommends zookeeper-bin
                -d 'java-runtime-headless | java2-runtime-headless | default-jre'
-               -d libcurl3
+               -d $libcurl_package
                -d libevent-dev
                -d libsvn1
                -d libsasl2-modules


### PR DESCRIPTION
Ubuntu 18.04 (Bionic) uses libcurl4 instead fo libcurl3 so we
special-case the dependencies to ensure that for this version, we use
the former.