### PR TITLE
Add support for Debian 10 builds

### DIFF
--- a/build_mesos
+++ b/build_mesos
@@ -285,7 +285,7 @@ function init_scripts {
       mkdir -p usr/lib/systemd/system
       cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
-    debian/8*|debian/9*|ubuntu/15*|ubuntu/16*|ubuntu/17*|ubuntu/18*)
+    debian/8*|debian/9*|debian/10*|ubuntu/15*|ubuntu/16*|ubuntu/17*|ubuntu/18*)
       mkdir -p lib/systemd/system
       cp "$this"/systemd/master.systemd lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd lib/systemd/system/mesos-slave.service ;;
@@ -344,8 +344,8 @@ function find_gem_bin {
 function deb_ {
   local libcurl_package
   case "$linux" in
-    ubuntu/18*) libcurl_package="libcurl4" ;;
-    *)          libcurl_package="libcurl3" ;;
+    ubuntu/18*|debian/10*) libcurl_package="libcurl4" ;;
+    *)                     libcurl_package="libcurl3" ;;
   esac
 
   local opts=( -t deb

--- a/debian/10/mesos.postinst
+++ b/debian/10/mesos.postinst
@@ -1,0 +1,3 @@
+ldconfig
+systemctl enable mesos-master
+systemctl enable mesos-slave

--- a/debian/10/mesos.postrm
+++ b/debian/10/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+


### PR DESCRIPTION
Debian 10 uses libcurl4, so that's really the only major change here.

Did encounter some issues building with openjdk-11 thanks to [javadoc](https://bugs.openjdk.java.net/browse/JDK-8212233),
so using openjdk-8 might be the way to go for builds. Have not found a
clear way around that which wouldn't involve patching Mesos yet, but
there's probably something.