### PR TITLE
Debian buster package #118

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,19 @@ Apache Mesos is a cluster manager that provides efficient resource isolation and
 
 ## Packaging Requirements
 
+# Debian 9 and Ubuntu 14
 ```bash
-sudo apt-get install ruby ruby-dev python-dev autoconf automake git make libssl-dev libcurl3 libtool
+sudo apt-get install ruby ruby-dev python-dev autoconf automake default-jdk dpkg-dev git make \
+  libssl-dev libcurl3 libtool libapr1 libapr1-dev libcurl3 libcurl4-openssl-dev maven libsasl2-2 \
+  libsasl2-dev libsvn-dev zlib1g-dev libevent-dev
+sudo gem install fpm
+```
+
+# Debian 10 and Ubuntu 18
+```bash
+sudo apt-get install autoconf automake default-jdk dpkg-dev git libapr1 libapr1-dev libboost-all-dev \
+  libcurl4 libcurl4-openssl-dev libsasl2-2 libsasl2-dev libssl-dev libsvn-dev libtool make maven \
+  python-dev ruby ruby-dev zlib1g-dev libevent-dev
 sudo gem install fpm
 ```
 

--- a/build_mesos
+++ b/build_mesos
@@ -108,6 +108,7 @@ function main {
 
 function go {
   if ! $prebuilt; then
+    patch_mesos
     build
   fi
   create_installation
@@ -143,6 +144,19 @@ function maybe_append_git_hash {
   else out "$1"
   fi
 }
+
+function patch_mesos {(
+  if [[ ! -f "mesos.patched" ]]; then
+    local patches=("$this/patch/$version"/*.patch)
+    for patch in $patches; do
+      if [[ -f "$patch" ]]; then
+        out "Applying mesos patch $patch ..."
+        patch -N -t -s -p1 < "$patch"
+      fi
+    done
+    touch "mesos.patched"
+  fi
+)}
 
 function checkout {
   local url=( $(url_split "$repo") )
@@ -285,7 +299,7 @@ function init_scripts {
       mkdir -p usr/lib/systemd/system
       cp "$this"/systemd/master.systemd usr/lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd usr/lib/systemd/system/mesos-slave.service ;;
-    debian/8*|debian/9*|ubuntu/15*|ubuntu/16*|ubuntu/17*|ubuntu/18*)
+    debian/8*|debian/9*|debian/10*|ubuntu/15*|ubuntu/16*|ubuntu/17*|ubuntu/18*)
       mkdir -p lib/systemd/system
       cp "$this"/systemd/master.systemd lib/systemd/system/mesos-master.service
       cp "$this"/systemd/slave.systemd lib/systemd/system/mesos-slave.service ;;
@@ -344,8 +358,8 @@ function find_gem_bin {
 function deb_ {
   local libcurl_package
   case "$linux" in
-    ubuntu/18*) libcurl_package="libcurl4" ;;
-    *)          libcurl_package="libcurl3" ;;
+    ubuntu/18*|debian/10*) libcurl_package="libcurl4" ;;
+    *)                     libcurl_package="libcurl3" ;;
   esac
 
   local opts=( -t deb
@@ -498,6 +512,10 @@ function configure_opts {
   if [[ $(vercomp "$version" 0.21.0) == '>' ]] ||
      [[ $(vercomp "$version" 0.21.0) == '=' ]]
   then options+=" --enable-optimize"
+  fi
+  if [[ "$linux" == debian/10* ]] ||
+     [[ "$linux" == ubuntu/18* ]]
+  then options+=" --with-boost=/usr/include/boost"
   fi
 
   # Pass on any configure flags to Mesos configure script.

--- a/debian/10/mesos.postinst
+++ b/debian/10/mesos.postinst
@@ -1,0 +1,3 @@
+ldconfig
+systemctl enable mesos-master
+systemctl enable mesos-slave

--- a/debian/10/mesos.postrm
+++ b/debian/10/mesos.postrm
@@ -1,0 +1,2 @@
+#rm -rf /var/log/mesos /etc/mesos
+

--- a/patch/1.10.0/MESOS-10129-maven.javadoc.fix.patch
+++ b/patch/1.10.0/MESOS-10129-maven.javadoc.fix.patch
@@ -1,0 +1,10 @@
+--- mesos.1.10.0/src/java/mesos.pom.in	2020-05-17 16:07:15.000000000 +0000
++++ mesos/src/java/mesos.pom.in		2020-05-17 08:23:09.000000000 +0000
+@@ -86,6 +86,7 @@
+         <configuration>
+           <sourcepath>@abs_top_srcdir@/src/java/src:@abs_top_builddir@/src/java/generated</sourcepath>
+           <subpackages>org.apache.mesos</subpackages>
++          <detectJavaApiLink>false</detectJavaApiLink>
+         </configuration>
+         <executions>
+           <execution>

--- a/patch/1.11.0/MESOS-10129-maven.javadoc.fix.patch
+++ b/patch/1.11.0/MESOS-10129-maven.javadoc.fix.patch
@@ -1,0 +1,10 @@
+--- mesos.1.10.0/src/java/mesos.pom.in	2020-05-17 16:07:15.000000000 +0000
++++ mesos/src/java/mesos.pom.in		2020-05-17 08:23:09.000000000 +0000
+@@ -86,6 +86,7 @@
+         <configuration>
+           <sourcepath>@abs_top_srcdir@/src/java/src:@abs_top_builddir@/src/java/generated</sourcepath>
+           <subpackages>org.apache.mesos</subpackages>
++          <detectJavaApiLink>false</detectJavaApiLink>
+         </configuration>
+         <executions>
+           <execution>


### PR DESCRIPTION
Adding support for Debian Buster 10

Tested at AWS EC2 instances using the official Debian Buster 10 image and OpenJDK 11

It also works for Debian 9 with OpenJDK 8

NOTE: this package requires a pending bug fix for Mesos but in the meantime is added as a patch here (more info at: https://issues.apache.org/jira/browse/MESOS-10129)

Issue #118 https://github.com/mesosphere/mesos-deb-packaging/issues/118